### PR TITLE
Support for route matching via a user-provided function

### DIFF
--- a/v1/router.go
+++ b/v1/router.go
@@ -114,7 +114,7 @@ func (r *Route) Params(p url.Values) *Route {
 }
 
 // Match via a user-provided function
-func (r *Route) Func(m Matcher) *Route {
+func (r *Route) Match(m Matcher) *Route {
 	r.matcher = m
 	return r
 }

--- a/v1/router.go
+++ b/v1/router.go
@@ -39,6 +39,9 @@ type matchState struct {
 // Route handler
 type Handler func(*Request, Context) (*Response, error)
 
+// Candidate route matcher
+type Matcher func(*Request, Route) bool
+
 // Middleware provides functionality to wrap a handler producing another handler
 type Middleware interface {
 	Wrap(Handler) Handler
@@ -66,6 +69,7 @@ type Route struct {
 	paths   []path.Path
 	params  url.Values
 	attrs   Attributes
+	matcher Matcher
 }
 
 // Set methods
@@ -106,6 +110,12 @@ func (r *Route) Params(p url.Values) *Route {
 	for k, v := range p {
 		r.params[k] = v
 	}
+	return r
+}
+
+// Match via a user-provided function
+func (r *Route) Func(m Matcher) *Route {
+	r.matcher = m
 	return r
 }
 
@@ -155,6 +165,12 @@ func (r Route) Matches(req *Request, state *matchState) *Match {
 			if !reflect.DeepEqual(v, c) {
 				return nil
 			}
+		}
+	}
+
+	if r.matcher != nil {
+		if !r.matcher(req, r) {
+			return nil
 		}
 	}
 
@@ -259,7 +275,7 @@ func (r *router) Add(p string, f Handler) *Route {
 	for _, e := range r.middleware {
 		f = e.Wrap(f)
 	}
-	v := &Route{f, nil, []path.Path{path.Parse(p)}, nil, nil}
+	v := &Route{f, nil, []path.Path{path.Parse(p)}, nil, nil, nil}
 	r.routes = append(r.routes, v)
 	return v
 }

--- a/v1/router_test.go
+++ b/v1/router_test.go
@@ -74,10 +74,10 @@ func TestRoutes(t *testing.T) {
 	r.Add("/a", funcB).Methods("PUT")
 	r.Add("/a", funcC)
 
-	r.Add("/b", funcF).Func(func(req *Request, route Route) bool {
+	r.Add("/b", funcF).Match(func(req *Request, route Route) bool {
 		return req.Header.Get("Check-Header") == "F"
 	})
-	r.Add("/b", funcG).Func(func(req *Request, route Route) bool {
+	r.Add("/b", funcG).Match(func(req *Request, route Route) bool {
 		return req.Header.Get("Check-Header") == "G"
 	})
 	r.Add("/b", funcD)


### PR DESCRIPTION
This adds support for a new `Route` configuration method which accepts a user-provided function to performs arbitrary matching on candidate requests in addition to built-in matching on path, method, and parameters. This method, `Match()`, is similar to the `Paths()`, `Methods()` and `Params()` methods of `Route` in that it imposes additional constraints on which requests will match it.

For example, we could use a user-provided matching function to require that a particular route only matches requests with a specific header set:

```go
r := router.New()
r.Add("/path", handler).Methods("GET").Match(func(req *router.Request, route router.Route) bool {
  return req.Header.Get("Some-Header") == "some_value"
})
```

When a function is configured on a route via `Match` it is only invoked on candidate request that match every other criteria of the route: the path, method, and query parameters, as applicable. In this case, if the matching function returns `true`, the route matches. If it returns `false`, the route does not match and the search continues.

Only one matcher function can be set on any given route. Setting `Match` repeatedly will overwrite the existing value.